### PR TITLE
[KIP-003] Retroactive Fixes to Missed Airdrop Participants

### DIFF
--- a/kips/kip-003.md
+++ b/kips/kip-003.md
@@ -6,7 +6,7 @@ Author: Keefer Taylor, Hover Labs <keefer@hover.engineering>
 
 [Kolibri DAO Token]() ("`kDAO`") is a governance token for the Kolibri system. 1M `kDAO` are in existence. 
 
-Of those `kDAO`, 350k `kDAO` were given to the Kolibri Community Fund. 15K `kDAO` were airdropped to the community. Initially, Hover Labs produced a list of airdrop participants, but upon further analysis, identified clusters of addresses that may represent sybil attacks and removed them from the airdrop. We announced this change on both our [Discord]() and [Twitter]() in advance.
+Of those `kDAO`, 350k `kDAO` were given to the Kolibri Community Fund. 150K `kDAO` were airdropped to the community. Initially, Hover Labs produced a list of airdrop participants, but upon further analysis, identified clusters of addresses that may represent sybil attacks and removed them from the airdrop. We announced this change on both our [Discord]() and [Twitter]() in advance.
 
 After the airdrop occurred, several credible entities have come forward with credible evidence that they were not performing a sybil attack. 
 


### PR DESCRIPTION
Draft of KIP-003, which seeks to reward users who were wrongly excluded from the airdrop to receive `kDAO` tokens.